### PR TITLE
Fix completion error when __to_print returns empty during shell initialization

### DIFF
--- a/functions/to.fish
+++ b/functions/to.fish
@@ -162,7 +162,11 @@ function __to_update_bookmark_completions
 
   # Bookmarks
   for bm in (__to_ls | sort -r)
-    complete -c to -k -n '__fish_use_subcommand; or __fish_seen_subcommand_from rm mv resolve' -r -a (echo $bm | string escape) -d (__to_print $bm)
+    set -l description (__to_print $bm)
+    if test -z "$description"
+      set description "$bm"  # Fallback to bookmark name if description is empty
+    end
+    complete -c to -k -n '__fish_use_subcommand; or __fish_seen_subcommand_from rm mv resolve' -r -a (echo $bm | string escape) -d "$description"
   end
 end
 


### PR DESCRIPTION
Fixes the completion error that occurs during Fish shell initialization when bookmark descriptions are empty.

## Problem Description
When Fish shell loads and the `__to_update_bookmark_completions` function runs, the `__to_print` function can return empty strings for bookmark descriptions. This causes the `complete` command to fail because the `-d` option requires a non-empty argument.

## Error Message
```
complete: -d: option requires an argument

~/.config/fish/functions/to.fish (line 165):
    complete -c to -k -n '__fish_use_subcommand; or __fish_seen_subcommand_from rm mv resolve' -r -a (echo $bm | string escape) -d (__to_print $bm)
    ^
in function '__to_update_bookmark_completions'
        called on line 1 of file ~/.config/fish/completions/to.fish
from sourcing file ~/.config/fish/completions/to.fish

(Type 'help complete' for related documentation)
```

## How to Reproduce
1. Install to-fish with Fisher: `fisher install joehillen/to-fish`
2. Create some bookmarks: `to add mybookmark ~/Documents`
3. Start a new Fish shell session
4. The error appears during completion initialization
5. Note that running `to ls` manually often fixes it temporarily until next shell restart

## Root Cause
The issue occurs when `__to_print $bm` returns an empty string during shell initialization, causing the `complete` command to receive an empty argument for the `-d` (description) option, which is invalid syntax.

## Solution
This PR adds a simple fallback mechanism:
- Check if `__to_print` returns an empty description
- If empty, use the bookmark name itself as the description
- This ensures the `-d` option always receives a valid non-empty argument

## Changes Made
- Added safety check in `__to_update_bookmark_completions` function
- Uses bookmark name as fallback when description is empty
- Zero functional impact on existing behavior
- Completions work correctly with or without descriptions

## Testing
- ✅ No functional changes to existing bookmark behavior
- ✅ Completions work correctly with valid descriptions
- ✅ Completions work correctly when falling back to bookmark names
- ✅ Error no longer occurs during shell initialization
- ✅ Manual testing with various bookmark scenarios

This is a minimal, safe fix that prevents the error while maintaining full backward compatibility.